### PR TITLE
[Fix] Guard against end of board

### DIFF
--- a/app/services/play_logic/game_logic/game_helpers.rb
+++ b/app/services/play_logic/game_logic/game_helpers.rb
@@ -364,7 +364,7 @@ module PlayLogic
             board_slice = board[move_row]
             move_col -= 1 while move_col - 1 > 0 && !board_slice[move_col - 1].zero?
             move_col += 1 while move_col < Game.board_size && board_slice[move_col].operation_tile?
-            until board_slice[move_col].zero?
+            while move_col < Game.board_size && !board_slice[move_col].zero?
               expression_coordinates << [move_row, move_col]
               move_col += 1
             end
@@ -372,7 +372,7 @@ module PlayLogic
             board_slice = board.transpose[move_col]
             move_row -= 1 while move_row - 1 > 0 && !board_slice[move_row - 1].zero?
             move_row += 1 while move_row < Game.board_size && board_slice[move_row].operation_tile?
-            until board_slice[move_row].zero?
+            while move_row < Game.board_size && !board_slice[move_row].zero?
               expression_coordinates << [move_row, move_col]
               move_row += 1
             end

--- a/app/services/play_logic/move_logic/move_helpers.rb
+++ b/app/services/play_logic/move_logic/move_helpers.rb
@@ -24,7 +24,7 @@ module PlayLogic
               unless move.row_num.all? { |row| (0..Game.board_size).include?(row) }
                 errors << :move_row_col_invalid
               end
-              unless move.col_num.all? { |col| (0..Game::BOARD_SIZE).include?(col) }
+              unless move.col_num.all? { |col| (0..Game.board_size).include?(col) }
                 errors << :move_row_col_invalid
               end
               unless move.tile_value.all? { |tile| Game::TILES_MAPPING.keys.include?(tile) }


### PR DESCRIPTION
## Description

An error occurs when a move is placed along the bottom or left edge of the board. Was caused by an out-of-bound error.