### PR TITLE
Remove 'return' causing extra round during end-of-game

### DIFF
--- a/app/services/play_logic/game_logic/game_helpers.rb
+++ b/app/services/play_logic/game_logic/game_helpers.rb
@@ -205,7 +205,6 @@ module PlayLogic
 
           if game.stage == 'in_play'
             game.stage = 'end_round_one'
-            return
           end
 
           return unless game.current_player == 'opponent'

--- a/spec/api/v1/moves_spec.rb
+++ b/spec/api/v1/moves_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe('Move API', type: :request) do
       it 'moves the game to the next stage' do
         subject
         game.reload
-        expect(game.stage).to(eq('end_round_one'))
+        expect(game.stage).to(eq('end_round_two'))
       end
 
       context 'and it is the initiators turn' do

--- a/spec/services/play_logic/game_logic/game_helpers_spec.rb
+++ b/spec/services/play_logic/game_logic/game_helpers_spec.rb
@@ -368,4 +368,76 @@ RSpec.describe(PlayLogic::GameLogic::GameHelpers) do
       end
     end
   end
+
+  describe 'evaluate_end_game' do
+    subject { described_class.evaluate_end_game(game: game) }
+
+    let(:current_player) { 'opponent' }
+    let(:available_tiles) { [] }
+    let(:stage) { 'in_play' }
+    let!(:game) do
+      build(
+        :game,
+        current_player: current_player,
+        available_tiles: available_tiles,
+        stage: stage
+      )
+    end
+
+    context 'when tiles remain' do
+      let(:available_tiles) { [1] }
+
+      it 'does not change game stage' do
+        subject
+        expect(game.stage).to(eq('in_play'))
+      end
+    end
+
+    context 'game is already complete' do
+      let(:stage) { 'complete' }
+
+      it 'does not change game stage' do
+        subject
+        expect(game.stage).to(eq('complete'))
+      end
+    end
+
+    context 'when the game is in play' do
+      context 'when opponent is the current player' do
+        it 'moves to round two' do
+          subject
+          expect(game.stage).to(eq('end_round_two'))
+        end
+      end
+
+      context 'when initiator is the current player' do
+        let(:current_player) { 'initiator' }
+
+        it 'moves to round one' do
+          subject
+          expect(game.stage).to(eq('end_round_one'))
+        end
+      end
+    end
+
+    context 'when the game is in round one or two' do
+      let(:stage) { 'end_round_one' }
+
+      context 'when opponent is the current player' do
+        it 'moves stage forward' do
+          subject
+          expect(game.stage).to(eq('end_round_two'))
+        end
+      end
+
+      context 'when initiator is the current player' do
+        let(:current_player) { 'initiator' }
+
+        it 'does not change game stage' do
+          subject
+          expect(game.stage).to(eq('end_round_one'))
+        end
+      end
+    end
+  end
 end

--- a/spec/services/play_logic/move_logic/move_manager_spec.rb
+++ b/spec/services/play_logic/move_logic/move_manager_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe(PlayLogic::MoveLogic::MoveManager) do
         it 'moves the game to end_round_one' do
           subject
           game.reload
-          expect(game.stage).to(eq('end_round_one'))
+          expect(game.stage).to(eq('end_round_two'))
         end
       end
 
@@ -166,10 +166,12 @@ RSpec.describe(PlayLogic::MoveLogic::MoveManager) do
           game.save!
         end
 
-        it 'moves the game to end_round_one' do
-          subject
-          game.reload
-          expect(game.stage).to(eq('end_round_one'))
+        context 'and it is the opponents turn' do
+          it 'moves the game to end_round_two' do
+            subject
+            game.reload
+            expect(game.stage).to(eq('end_round_two'))
+          end
         end
 
         context 'and it is the initiators turn' do


### PR DESCRIPTION
## Description

Remove 'return' causing extra round during end-of-game. Fixes end-of-game logic.